### PR TITLE
Remove dam_logo occourence

### DIFF
--- a/models/class.tx_cfcleaguefe_models_club.php
+++ b/models/class.tx_cfcleaguefe_models_club.php
@@ -87,7 +87,7 @@ class tx_cfcleaguefe_models_club extends tx_cfcleague_models_Club
     public static function findAll($clubUids, $saisonUids = '', $groupUids = '', $compUids = '')
     {
         // FIXME: Die Felder des Clubs aus der TCA laden.
-        $what = 'DISTINCT tx_cfcleague_club.uid, tx_cfcleague_club.name, tx_cfcleague_club.short_name, tx_cfcleague_club.dam_logo ';
+        $what = 'DISTINCT tx_cfcleague_club.uid, tx_cfcleague_club.name, tx_cfcleague_club.short_name ';
         $from = array(
             '
       tx_cfcleague_club


### PR DESCRIPTION
Prevents nearly all FE function to work properly.
No other references found.
No SQL found which creates this column.
Might be an old fragment when DAM was part of TYPO3.