### PR TITLE
Check for non-empty static_position in H2H comparison

### DIFF
--- a/Classes/Table/Football/ComparatorH2H.php
+++ b/Classes/Table/Football/ComparatorH2H.php
@@ -48,10 +48,10 @@ class ComparatorH2H implements IComparator
         $isH2HComparison = true; // = "is Head-to-head-comparison"
 
         // Zwangsabstieg prüfen
-        if ($t1['static_position']) {
+        if (!empty($t1['static_position'])) {
             return 1;
         }
-        if ($t2['static_position']) {
+        if (!empty($t2['static_position'])) {
             return -1;
         }
 


### PR DESCRIPTION
To avoid warnings like: 'Core: Error handler (FE): PHP Warning: Undefined array key "static_position"'