### PR TITLE
Add group check before ignoring age group configuration

### DIFF
--- a/Classes/Hook/MatchHistoryHook.php
+++ b/Classes/Hook/MatchHistoryHook.php
@@ -96,7 +96,7 @@ class MatchHistoryHook
         $srv = ServiceRegistry::getMatchService();
         $matchTable = $srv->getMatchTable();
 
-        if (!intval($formatter->configurations->get($confId.'ignoreAgeGroup'))) {
+        if ($group && !intval($formatter->configurations->get($confId.'ignoreAgeGroup'))) {
             $matchTable->setAgeGroups($group->getUid());
         }
         $matchTable->setHomeClubs($home->getUid().','.$guest->getUid());


### PR DESCRIPTION
If you do not need age groups at all it will nowadays fails here - added check to avoid this failing when no age group is set at all.